### PR TITLE
 Upgrade CMake script to install the library target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,7 @@ target_include_directories(ulib
                            PRIVATE "${ULIB_PRIVATE_HEADERS_DIR}")
 target_precompile_headers(ulib PUBLIC ${ULIB_USER_HEADERS})
 add_dependencies(ulib ulib-headers)
+install(TARGETS ulib)
 
 if(ULIB_LIBRARY_TYPE STREQUAL "SHARED")
     target_compile_definitions(ulib PUBLIC ULIB_SHARED)


### PR DESCRIPTION
Without this change, the "-DCMAKE_INSTALL_PREFIX=/usr/local" command line argument will not properly distribute the compiled binaries to the specified location.